### PR TITLE
Add a map for can-route-pushstate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/default/index.js
+++ b/default/index.js
@@ -149,6 +149,40 @@ module.exports = Generator.extend({
                 data.substring(commentEndIndex + commentEndText.length);
         }
 
+        // Add buildElectron variable
+        var buildElectronVarIndex = newContent.indexOf("var buildElectron");
+        if(buildElectronVarIndex === -1) {
+          newContent = "var buildElectron = process.argv.indexOf(\"electron\") > 0;\n\n" + newContent;
+        }
+
+        // Add buildCordova variable
+        var buildCordovaVarIndex = newContent.indexOf("var buildCordova");
+        if(buildCordovaVarIndex === -1) {
+          newContent = "var buildCordova = process.argv.indexOf(\"cordova\") > 0;\n" + newContent;
+        }
+
+        // The generator-donejs version of build.js, unedited
+        var defaultStealToolsBuildStart = "stealTools.build({},";
+        var buildStartIndex = data.indexOf(defaultStealToolsBuildStart);
+        if(buildStartIndex > 0) {
+          newContent = newContent.replace(defaultStealToolsBuildStart, `stealTools.build({
+  map: ? (buildElectron || buildCordova) ? {
+    "can-route-pushstate": "can-route-hash"
+  } : {}
+},`);
+        } else {
+          // A custom configuration version
+          var configedStealToolsBuildStart = "stealTools.build({\n";
+          buildStartIndex = data.indexOf(configedStealToolsBuildStart);
+          if(buildStartIndex > 0) {
+            newContent = newContent.replace(configedStealToolsBuildStart, `stealTools.build({
+    map: ? (buildElectron || buildCordova) ? {
+      "can-route-pushstate": "can-route-hash"
+    }, : {},
+  `);
+          }
+        }
+
         fs.writeFile(buildJs, newContent, function() {
           buildJsDeferred.resolve();
         });

--- a/default/index.js
+++ b/default/index.js
@@ -3,6 +3,7 @@ var os = require('os');
 var Q = require('q');
 var fs = require('fs');
 var ejs = require('ejs');
+var addRoutingMap = require('donejs-generator-common/routing').addRoutingMap;
 
 var platform = {
   macos: os.platform() === 'darwin',
@@ -149,39 +150,7 @@ module.exports = Generator.extend({
                 data.substring(commentEndIndex + commentEndText.length);
         }
 
-        // Add buildElectron variable
-        var buildElectronVarIndex = newContent.indexOf("var buildElectron");
-        if(buildElectronVarIndex === -1) {
-          newContent = "var buildElectron = process.argv.indexOf(\"electron\") > 0;\n\n" + newContent;
-        }
-
-        // Add buildCordova variable
-        var buildCordovaVarIndex = newContent.indexOf("var buildCordova");
-        if(buildCordovaVarIndex === -1) {
-          newContent = "var buildCordova = process.argv.indexOf(\"cordova\") > 0;\n" + newContent;
-        }
-
-        // The generator-donejs version of build.js, unedited
-        var defaultStealToolsBuildStart = "stealTools.build({},";
-        var buildStartIndex = data.indexOf(defaultStealToolsBuildStart);
-        if(buildStartIndex > 0) {
-          newContent = newContent.replace(defaultStealToolsBuildStart, `stealTools.build({
-  map: ? (buildElectron || buildCordova) ? {
-    "can-route-pushstate": "can-route-hash"
-  } : {}
-},`);
-        } else {
-          // A custom configuration version
-          var configedStealToolsBuildStart = "stealTools.build({\n";
-          buildStartIndex = data.indexOf(configedStealToolsBuildStart);
-          if(buildStartIndex > 0) {
-            newContent = newContent.replace(configedStealToolsBuildStart, `stealTools.build({
-    map: ? (buildElectron || buildCordova) ? {
-      "can-route-pushstate": "can-route-hash"
-    }, : {},
-  `);
-          }
-        }
+        newContent = addRoutingMap(newContent, data);
 
         fs.writeFile(buildJs, newContent, function() {
           buildJsDeferred.resolve();

--- a/default/templates/electronOptions.ejs
+++ b/default/templates/electronOptions.ejs
@@ -12,9 +12,6 @@ var electronOptions = {
 
 var stealElectron = require("steal-electron");
 
-// Check if the electron option is passed.
-var buildElectron = process.argv.indexOf("electron") > 0;
-
 if(buildElectron) {
   buildPromise = buildPromise.then(function(buildResult){
     return stealElectron(electronOptions, buildResult);

--- a/default/templates/header.ejs
+++ b/default/templates/header.ejs
@@ -4,9 +4,9 @@ var buildElectron = process.argv.indexOf("electron") > 0;
 var buildCordova = process.argv.indexOf("cordova") > 0;
 
 var buildPromise = stealTools.build({
-  map ? (buildElectron || buildCordova) ? {
+  map: ((buildElectron || buildCordova) ? {
     "can-route-pushstate": "can-route-hash"
-  } : {}
+  } : {})
 }, {
   bundleAssets: true
 });

--- a/default/templates/header.ejs
+++ b/default/templates/header.ejs
@@ -1,7 +1,12 @@
 var stealTools = require("steal-tools");
 
+var buildElectron = process.argv.indexOf("electron") > 0;
+var buildCordova = process.argv.indexOf("cordova") > 0;
+
 var buildPromise = stealTools.build({
-  config: __dirname + "/package.json!npm"
+  map ? (buildElectron || buildCordova) ? {
+    "can-route-pushstate": "can-route-hash"
+  } : {}
 }, {
   bundleAssets: true
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "generator"
   ],
   "dependencies": {
-    "donejs-generator-common": "^1.0.1",
+    "donejs-generator-common": "^1.0.5",
     "ejs": "^2.5.2",
     "lodash": "^4.16.4",
     "q": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "generator"
   ],
   "dependencies": {
+    "donejs-generator-common": "^1.0.1",
     "ejs": "^2.5.2",
     "lodash": "^4.16.4",
     "q": "^1.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,8 @@ describe('donejs-electron', function() {
         assert.fileContent('build.js', /main: "electron-main.js"/);
         assert.fileContent('build.js', /platforms: \["darwin"\]/);
         assert.fileContent('build.js', /archs: \["ia32"\]/);
+        assert.fileContent('build.js', /buildElectron/);
+        assert.fileContent('build.js', /map ?/);
       });
     });
 
@@ -48,6 +50,9 @@ describe('donejs-electron', function() {
         assert.fileContent('build.js', /main: "my-electron-main.js"/);
         assert.fileContent('build.js', /platforms: \["win32"\]/);
         assert.fileContent('build.js', /archs: \["x64"\]/);
+        assert.fileContent('build.js', /var buildElectron/);
+        assert.fileContent('build.js', /var buildCordova/);
+        assert.fileContent('build.js', /map ?/);
       });
     });
 
@@ -74,6 +79,9 @@ describe('donejs-electron', function() {
         assert.fileContent('build.js', /platforms: \["darwin","linux"\]/);
         assert.fileContent('build.js', /archs: \["ia32","x64"\]/);
         assert.noFileContent('build.js', /previous electron options/);
+        assert.fileContent('build.js', /var buildElectron/);
+        assert.fileContent('build.js', /var buildCordova/);
+        assert.fileContent('build.js', /map ?/);
       });
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ describe('donejs-electron', function() {
         assert.fileContent('build.js', /platforms: \["darwin"\]/);
         assert.fileContent('build.js', /archs: \["ia32"\]/);
         assert.fileContent('build.js', /buildElectron/);
-        assert.fileContent('build.js', /map ?/);
+        assert.fileContent('build.js', /map: \(/);
       });
     });
 
@@ -57,7 +57,7 @@ describe('donejs-electron', function() {
         assert.fileContent('build.js', /archs: \["x64"\]/);
         assert.fileContent('build.js', /var buildElectron/);
         assert.fileContent('build.js', /var buildCordova/);
-        assert.fileContent('build.js', /map ?/);
+        assert.fileContent('build.js', /map: \(/);
       });
     });
 
@@ -86,7 +86,7 @@ describe('donejs-electron', function() {
         assert.noFileContent('build.js', /previous electron options/);
         assert.fileContent('build.js', /var buildElectron/);
         assert.fileContent('build.js', /var buildCordova/);
-        assert.fileContent('build.js', /map ?/);
+        assert.fileContent('build.js', /map: \(/);
       });
     });
 
@@ -108,7 +108,7 @@ describe('donejs-electron', function() {
         assert.file(['build.js']);
 
         var file = readFile('build.js');
-        var exp = /map ?/g;
+        var exp = /map: \(/g;
         var mappings = 0;
 
         while(exp.exec(file)) {

--- a/test/templates/donejs-electron-with-map/build.js
+++ b/test/templates/donejs-electron-with-map/build.js
@@ -5,9 +5,9 @@ var buildCordova = process.argv.indexOf("cordova") > 0;
 var stealTools = require("steal-tools");
 
 var buildPromise = stealTools.build({
-  map: ? (buildElectron || buildCordova) ? {
+  map: ((buildElectron || buildCordova) ? {
     "can-route-pushstate": "can-route-hash"
-  }, : {},
+  } : {}),
   config: __dirname + "/package.json!npm"
 }, {
   bundleAssets: true

--- a/test/templates/donejs-electron-with-map/build.js
+++ b/test/templates/donejs-electron-with-map/build.js
@@ -1,9 +1,13 @@
 var buildElectron = process.argv.indexOf("electron") > 0;
+var buildCordova = process.argv.indexOf("cordova") > 0;
 
 // generator-donejs + donejs-electron build.js
 var stealTools = require("steal-tools");
 
 var buildPromise = stealTools.build({
+  map: ? (buildElectron || buildCordova) ? {
+    "can-route-pushstate": "can-route-hash"
+  }, : {},
   config: __dirname + "/package.json!npm"
 }, {
   bundleAssets: true

--- a/test/templates/generator-donejs/build.js
+++ b/test/templates/generator-donejs/build.js
@@ -2,8 +2,6 @@
 var stealTools = require("steal-tools");
 
 /* exported buildPromise */
-var buildPromise = stealTools.build({
-  config: __dirname + "/package.json!npm"
-}, {
+var buildPromise = stealTools.build({}, {
   bundleAssets: true
 });


### PR DESCRIPTION
This adds a mapping for can-route-pushstate to can-route-hash when
building for electron.

This is part of #1125

This is a breaking change.